### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PertuyF @bgruening @cbrueffer @conda-forge/r @daler @dbast @jdblischak @johanneskoester @tbillet17
+* @PertuyF @conda-forge/r @tbillet17

--- a/README.md
+++ b/README.md
@@ -116,12 +116,6 @@ Feedstock Maintainers
 =====================
 
 * [@PertuyF](https://github.com/PertuyF/)
-* [@bgruening](https://github.com/bgruening/)
-* [@cbrueffer](https://github.com/cbrueffer/)
 * [@conda-forge/r](https://github.com/conda-forge/r/)
-* [@daler](https://github.com/daler/)
-* [@dbast](https://github.com/dbast/)
-* [@jdblischak](https://github.com/jdblischak/)
-* [@johanneskoester](https://github.com/johanneskoester/)
 * [@tbillet17](https://github.com/tbillet17/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,11 +40,5 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-    - johanneskoester
-    - bgruening
-    - daler
-    - jdblischak
-    - cbrueffer
-    - dbast
     - PertuyF
     - tbillet17


### PR DESCRIPTION

Remove individually listed maintainers that are members of the conda-forge/r team

Followed a similar strategy from the docs for updating the maintainers. Unfortunately it doesn't appear possible to skip the CI jobs in the PR itself, even the example PR had jobs run

https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
